### PR TITLE
fix: handle collateral return output for babbage txs in `BalanceByAddress` and `UtxoByAddress`

### DIFF
--- a/src/reducers/balance_by_address.rs
+++ b/src/reducers/balance_by_address.rs
@@ -89,8 +89,8 @@ impl Reducer {
             self.process_inbound_txo(&ctx, &input, output)?;
         }
 
-        for (_idx, tx_output) in tx.outputs().iter().enumerate() {
-            self.process_outbound_txo(tx_output, output)?;
+        if let Some(coll_ret) = tx.collateral_return() {
+            self.process_outbound_txo(&coll_ret, output)?;
         }
 
         Ok(())

--- a/src/reducers/utxo_by_address.rs
+++ b/src/reducers/utxo_by_address.rs
@@ -97,9 +97,10 @@ impl Reducer {
         for input in tx.collateral().iter().map(|i| i.output_ref()) {
             self.process_inbound_txo(&ctx, &input, output)?;
         }
-
-        for (idx, tx_output) in tx.outputs().iter().enumerate() {
-            self.process_outbound_txo(tx, tx_output, idx, output)?;
+        
+        if let Some(coll_ret) = tx.collateral_return() {
+            let idx = tx.outputs().len();
+            self.process_outbound_txo(tx, &coll_ret, idx, output)?;
         }
 
         Ok(())


### PR DESCRIPTION
Collateral is handle differently for transactions from the different eras which fail phase-2 validation/are not valid:

In the Alonzo era the collateral inputs are consumed entirely, and none of the standard inputs or outputs are consumed/created.

In the Babbage era the collateral inputs are consumed but there is an optional collateral return output which is created if present in the transaction. This return output UTXO is given the TxIn of `txhash:idx` where idx is the number of standard outputs that would have been created by the transaction (i.e, it's given the next available index).